### PR TITLE
fix: detect no-op revisions to prevent false-positive success

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import type { RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
-import { verifyPRExists, checkPRHasChanges } from "./github.js";
+import { verifyPRExists, checkPRHasChanges, getRemoteBranchSha } from "./github.js";
 
 export interface RevisionResult {
   success: boolean;
@@ -313,6 +313,13 @@ export async function revisePRFeedback(
 ): Promise<RevisionResult> {
   logger.info(`Starting PR revision for ${config.name}`);
 
+  // Capture the feature branch's HEAD SHA before invoking Claude so we can
+  // detect the no-op case where Claude exits 0 without pushing any commits.
+  // Without this, a silent no-op would be reported as success and the
+  // orchestrator would (incorrectly) transition labels to "pr under review",
+  // hiding the fact that the requested fix was never applied.
+  const beforeSha = getRemoteBranchSha(config.githubRepo, config.featureBranch, config.repoPath, logger);
+
   const prContext = prNumber
     ? `\n\nCONTEXT: PR #${prNumber} needs revision. Linked issues: ${(issueNumbers || []).map(n => `#${n}`).join(", ")}. Read the review comments on PR #${prNumber} to understand what changes are requested.`
     : "";
@@ -349,6 +356,25 @@ Work autonomously. Do not ask questions.`;
     const error = stderrMsg || stdoutTail || `exit code ${result.exitCode}`;
     logger.error(`Claude CLI exited with code ${result.exitCode}: ${error}`);
     return { success: false, error };
+  }
+
+  // Post-revision self-check: confirm Claude actually pushed commits to the
+  // feature branch. A clean exit with no SHA change means the revision was a
+  // silent no-op (skill misfire, agent decided "nothing to fix", failed push,
+  // etc.). Treat it as a failure so the orchestrator does not transition labels
+  // to "pr under review" — that would lie about the PR's state and cause the
+  // EM to re-review unchanged code.
+  //
+  // Conservative on lookup failures: if either SHA is null (transient gh
+  // error), we trust the exit code rather than fail spuriously.
+  const afterSha = getRemoteBranchSha(config.githubRepo, config.featureBranch, config.repoPath, logger);
+  if (beforeSha && afterSha && beforeSha === afterSha) {
+    const outputTail = result.stdout.slice(-500).trim();
+    if (outputTail) {
+      logger.warn("Claude output (last 500 chars):\n" + outputTail);
+    }
+    logger.error(`PR revision completed (exit 0) but no commits were pushed to ${config.featureBranch} (SHA unchanged at ${beforeSha.slice(0, 10)}) — marking as failed`);
+    return { success: false, error: "no commits pushed — revision was a no-op" };
   }
 
   logger.info(`PR revision completed successfully for ${config.name}`);

--- a/src/github.ts
+++ b/src/github.ts
@@ -544,6 +544,31 @@ export function checkPRHasChanges(
   }
 }
 
+/**
+ * Read the current HEAD SHA of a remote branch via the GitHub API.
+ * Returns null on lookup failure so callers can decide how to react —
+ * a transient gh error should not be conflated with a real "branch unchanged"
+ * signal.
+ */
+export function getRemoteBranchSha(
+  repo: string,
+  branch: string,
+  cwd: string,
+  logger: Logger,
+): string | null {
+  try {
+    const sha = gh([
+      "api",
+      `repos/${repo}/branches/${encodeURIComponent(branch)}`,
+      "--jq", ".commit.sha",
+    ], cwd);
+    return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+  } catch (err) {
+    logger.warn("getRemoteBranchSha: gh api failed", { ...formatGhError(err), repo, branch });
+    return null;
+  }
+}
+
 // --- Branch Sync ---
 
 export interface BranchDrift {


### PR DESCRIPTION
## Summary

`revisePRFeedback` returned `{success: true}` whenever Claude exited 0, regardless of whether commits were actually pushed. The orchestrator then transitioned issue labels from `pr pending actions` → `pr under review` and reset the failure counter — falsely signaling that the PR was ready for re-review when the underlying code was unchanged.

## Repro

Observed 2026-05-02 on `xrgarcia/jerky_event_processor#5`:

```
16:46:09  Triggering PR revision for jerky-event-processor — PR #5, issues: #4
16:46:09  Starting PR revision for jerky-event-processor
16:46:51  PR revision completed successfully    ← claims success after 42s
16:46:53  Transitioned issue #4 labels: "pr pending actions" → "pr under review"
```

`features` branch tip: same commit `6ae1c57492` (dated 2026-05-02T16:14:05Z, the original PR commit, pre-dating the review). No revision was actually pushed. The EM (slashbin-engineering-manager) had to manually intervene to reset labels and document the no-op cycle, defeating the entire purpose of the automated revision phase.

## Root cause

`agent.ts:revisePRFeedback` only checks Claude's exit code and timeout. It has no signal for "did Claude actually do anything?". Possible upstream causes for the no-op (skill misfire, Claude deciding "nothing to fix", a silently-failed `git push`, etc.) all collapse to the same failure mode: silent false-positive success.

The implement path already has a self-check for the analogous case (`checkPRHasChanges` after PR creation, line 248). Revision was missing the equivalent.

## Fix

Capture the feature branch's HEAD SHA before invoking Claude. Re-check after a clean exit. If unchanged → return failure with `"no commits pushed — revision was a no-op"`. The orchestrator's existing failure-retry path then handles it correctly: increment failure count, leave labels as `pr pending actions`, back off after `MAX_RETRIES`.

**Conservative on lookup failures**: a transient `gh api` error returning null SHA is NOT treated as a no-op — we trust Claude's exit code rather than fail spuriously. Only `beforeSha === afterSha` (both non-null, both 40-hex) is treated as a no-op.

## Files

- [`src/github.ts`](src/github.ts): new `getRemoteBranchSha(repo, branch, cwd, logger): string | null` helper, mirrors the style of the existing `gh()` wrappers and `checkPRHasChanges`.
- [`src/agent.ts`](src/agent.ts): capture before/after SHA in `revisePRFeedback`, fail on confirmed no-op.

## Backward compat

No `.ai-agent.json` / env-var / default-value changes. Pure internal runtime behavior fix. Per the OSS contract: additive opt-in only — this qualifies as a bug fix that makes existing behavior match what the function name and log messages already imply.

If a downstream user's revision skill intentionally no-ops (e.g., "review feedback was informational, no fix needed"), those will now be marked failures and back off after `MAX_RETRIES` cycles — which is the right behavior, since the EM-side review still expects a code change. If the EM thought nothing needed to change, the EM would have approved, not requested changes.

## Test plan

- [ ] Manual: re-run the jerky_event_processor#5 revision with this fix in place. Confirm Foreman either (a) actually applies a fix and pushes, or (b) reports `no commits pushed — revision was a no-op`, leaves labels as `pr pending actions`, and backs off after 3 attempts. Either outcome is correct; the prior false-success outcome is the one that's now impossible.
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)