### PR TITLE
fix: only label issues actually referenced by the implementation PR

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -723,3 +723,69 @@ export function verifyPRExists(
   }
 }
 
+/**
+ * Read the open feature PR's body + title + commit messages and extract every
+ * issue number referenced via standard GitHub keywords ("Related to #N",
+ * "Closes #N", "Fixes #N", "Resolves #N", "Refs #N", "See #N"). Used by the
+ * orchestrator to know which subset of `actionableIssues` the implementation
+ * skill actually addressed — under the canonical one-issue-per-invocation
+ * skill (jerky_data_receiver#43 and friends), the skill picks one issue from a
+ * batch but the orchestrator must NOT label the unpicked issues as
+ * "pr under review", or they get stuck waiting forever for revision activity.
+ *
+ * Returns the parsed issue numbers (deduped). On lookup or parse failure
+ * returns null so callers can fall back to existing behavior rather than
+ * silently dropping issues from the label transition.
+ */
+export function getReferencedIssuesFromOpenPR(
+  repo: string,
+  headBranch: string,
+  baseBranch: string,
+  cwd: string,
+  logger?: Logger,
+): number[] | null {
+  try {
+    const json = gh([
+      "pr", "list",
+      "--repo", repo,
+      "--head", headBranch,
+      "--base", baseBranch,
+      "--state", "open",
+      "--json", "number,title,body,commits",
+      "--limit", "1",
+    ], cwd);
+    const prs = JSON.parse(json || "[]");
+    if (prs.length === 0) return null;
+    const pr = prs[0];
+
+    // Aggregate every text source the implementation skill might have used to
+    // reference the issue: PR title (`feat: foo (#N)`), PR body (`Related to #N`,
+    // `Closes #N`, etc.), and each commit message in the PR.
+    const sources: string[] = [pr.title || "", pr.body || ""];
+    for (const c of pr.commits || []) {
+      sources.push(c.messageHeadline || "");
+      sources.push(c.messageBody || "");
+    }
+    const text = sources.join("\n");
+
+    // Match keywords + optional `to`/`:` + `#<number>`. Case-insensitive.
+    // Also catches the trailing `(#N)` style commonly written by the canonical
+    // implement-approved-issues skill in PR titles.
+    const found = new Set<number>();
+    const keywordRe = /\b(?:related\s+to|closes?|fixes?|resolves?|refs?|see)\s*:?\s*#(\d+)/gi;
+    const titleSuffixRe = /\(#(\d+)\)/g;
+    for (const m of text.matchAll(keywordRe)) {
+      const n = parseInt(m[1], 10);
+      if (Number.isFinite(n)) found.add(n);
+    }
+    for (const m of text.matchAll(titleSuffixRe)) {
+      const n = parseInt(m[1], 10);
+      if (Number.isFinite(n)) found.add(n);
+    }
+    return Array.from(found).sort((a, b) => a - b);
+  } catch (err) {
+    logger?.warn("getReferencedIssuesFromOpenPR: gh pr list failed", { ...formatGhError(err), repo, headBranch, baseBranch });
+    return null;
+  }
+}
+

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -6,6 +6,7 @@ import {
   findPendingRevisions,
   transitionRevisionLabels,
   transitionImplementationLabels,
+  getReferencedIssuesFromOpenPR,
   findReadyForProdIssues,
   findOpenPromotionPR,
   createPromotionPR,
@@ -247,9 +248,49 @@ async function tryBatchImplementation(
       lastFailureReason.delete(repoName);
       failureHitMaxAt.delete(repoName);
 
+      // Filter the discovered batch to only issues the implementation skill
+      // actually addressed in the resulting PR. The canonical
+      // implement-approved-issues skill picks ONE issue per invocation
+      // (jerky_data_receiver#43 / PR #44) — labeling all N discovered issues
+      // as "pr under review" wedges the unpicked ones forever (they look like
+      // they have a PR open but the PR doesn't reference them, so revision
+      // never fires). Parse the open PR's body + title + commits for keyword
+      // references and intersect with the discovery list.
+      //
+      // Conservative on lookup failure: if the parser returns null (gh error)
+      // OR returns zero referenced issues from the discovery batch (skill
+      // shipped something but didn't reference any of them, e.g. legacy
+      // bundling pre-#43), fall back to the discovery list and keep the
+      // existing behavior. The fallback path matches what we did before this
+      // fix — it's the SAFE direction (over-label, EM cleans up) versus
+      // under-labeling (issues stuck silent).
+      const referencedAll = getReferencedIssuesFromOpenPR(
+        repoConfig.githubRepo,
+        repoConfig.featureBranch,
+        repoConfig.baseBranch,
+        repoConfig.repoPath,
+        repoLogger,
+      );
+      const intersected = referencedAll
+        ? actionableIssues.filter((n) => referencedAll.includes(n))
+        : null;
+      const issuesActuallyImplemented =
+        intersected && intersected.length > 0 ? intersected : actionableIssues;
+      if (intersected && intersected.length > 0 && intersected.length < actionableIssues.length) {
+        const dropped = actionableIssues.filter((n) => !intersected.includes(n));
+        repoLogger.info(
+          `Skill implemented ${intersected.length}/${actionableIssues.length} discovered issues — labeling only the implemented set`,
+          { implemented: intersected, deferred: dropped },
+        );
+      } else if (intersected && intersected.length === 0) {
+        repoLogger.warn(
+          `Open PR found but its body/title/commits do not reference any discovered issue (#${actionableIssues.join(", #")}) — falling back to label all discovered issues; investigate the skill's PR formatting`,
+        );
+      }
+
       // Persist implemented issue numbers to prevent re-implementation loops
       const updatedState = loadRepoState(repoName);
-      for (const issueNum of actionableIssues) {
+      for (const issueNum of issuesActuallyImplemented) {
         if (!updatedState.implemented.includes(issueNum)) {
           updatedState.implemented.push(issueNum);
         }
@@ -260,9 +301,9 @@ async function tryBatchImplementation(
       saveRepoState(repoName, updatedState);
 
       // Add "pr under review" label so EM knows PRs are ready for review
-      transitionImplementationLabels(repoConfig.githubRepo, actionableIssues, repoConfig.repoPath, repoLogger);
+      transitionImplementationLabels(repoConfig.githubRepo, issuesActuallyImplemented, repoConfig.repoPath, repoLogger);
 
-      repoLogger.info(`Batch implementation succeeded — tracked ${actionableIssues.map(n => `#${n}`).join(", ")} in state`, { prUrl: result.prUrl });
+      repoLogger.info(`Batch implementation succeeded — tracked ${issuesActuallyImplemented.map(n => `#${n}`).join(", ")} in state`, { prUrl: result.prUrl });
       events?.push({ message: `Feature PR on ${repoConfig.githubRepo}: ${result.prUrl || "(commits added to existing PR)"}`, level: "info" });
     } else if (result.skipped) {
       // Deliberate no-op by the agent (e.g., issue body says "investigate first").


### PR DESCRIPTION
## Summary

Under the canonical one-issue-per-invocation `implement-approved-issues` skill (per `jerky_data_receiver#43` / PR #44), the skill picks ONE issue from a batch and opens a PR referencing only that issue. The orchestrator was iterating the original discovery list and labeling **all N** discovered issues as `pr under review` — wedging the unpicked issues. They look like a PR is open against them, so revision never fires; they sit silent until the EM manually strips the label.

## Repro (2026-05-02, jerky-event-processor cycle 48)

```
20:26:08  Found 2 actionable issue(s) with no linked PR: #13, #14
20:26:08  Triggering batch implementation for jerky-event-processor
20:28:03  PR #15 modifies 1 file(s): server/worker.ts          ← skill chose 1
20:28:03  PR created and verified: ...pull/15
20:28:04  Added "pr under review" to issue #13 after implementation   ← correct
20:28:05  Added "pr under review" to issue #14 after implementation   ← BUG
20:28:05  Batch implementation succeeded — tracked #13, #14 in state
```

PR #15 body: `Related to #13`. Diff: `server/worker.ts` only. Nothing about #14.

## Fix

`src/github.ts`: new `getReferencedIssuesFromOpenPR(repo, headBranch, baseBranch, cwd, logger?): number[] | null`. Reads the open PR via `gh pr list --json number,title,body,commits`, aggregates title + body + per-commit messages, parses for standard keywords (`Related to #N`, `Closes #N`, `Fixes #N`, `Resolves #N`, `Refs #N`, `See #N`) plus the trailing `(#N)` style. Returns deduped sorted array, or `null` on lookup failure.

`src/orchestrator.ts`: after `implementApprovedIssues` returns success, call the helper, intersect with the discovery list, use the intersection for `state.implemented` and `transitionImplementationLabels`. Falls back to the discovery list on null parse OR empty intersection — over-labeling is recoverable, under-labeling silently drops issues. Logs at info level when filtering succeeds, warn when falling back.

## Files

- `src/github.ts` — new helper, ~70 lines incl. JSDoc
- `src/orchestrator.ts` — replaces direct use of `actionableIssues` with the filtered `issuesActuallyImplemented`, ~30 lines incl. comment

## Backward compat

No `.ai-agent.json`, env-var, default-value, or wire-format changes. Pure internal behavior fix. Repos still on the legacy bundling skill (pre-#43) hit the fallback path and get the existing behavior. Repos on the canonical skill get the correct one-issue labeling.

## Test plan

- [ ] Manual: file 2 approved issues on a Foreman-managed repo, watch cycle. Confirm only the issue picked by the skill (per its PR body) gets `pr under review`. The other stays `approved` and gets re-picked next cycle.
- [ ] `npm run typecheck` ✅
- [ ] `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)