### PR TITLE
fix: skip labeling when open PR doesn't reference any discovered issue (#16)

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -250,20 +250,28 @@ async function tryBatchImplementation(
 
       // Filter the discovered batch to only issues the implementation skill
       // actually addressed in the resulting PR. The canonical
-      // implement-approved-issues skill picks ONE issue per invocation
-      // (jerky_data_receiver#43 / PR #44) — labeling all N discovered issues
-      // as "pr under review" wedges the unpicked ones forever (they look like
-      // they have a PR open but the PR doesn't reference them, so revision
-      // never fires). Parse the open PR's body + title + commits for keyword
-      // references and intersect with the discovery list.
+      // implement-approved-issues skill picks ONE issue per invocation —
+      // labeling all N discovered issues as "pr under review" wedges the
+      // unpicked ones forever (they look like they have a PR open but the
+      // PR doesn't reference them, so revision never fires). Parse the open
+      // PR's body + title + commits for keyword references and intersect
+      // with the discovery list.
       //
-      // Conservative on lookup failure: if the parser returns null (gh error)
-      // OR returns zero referenced issues from the discovery batch (skill
-      // shipped something but didn't reference any of them, e.g. legacy
-      // bundling pre-#43), fall back to the discovery list and keep the
-      // existing behavior. The fallback path matches what we did before this
-      // fix — it's the SAFE direction (over-label, EM cleans up) versus
-      // under-labeling (issues stuck silent).
+      // Three cases:
+      //   1. intersected.length > 0 → label only the matched subset (the
+      //      typical canonical-skill case).
+      //   2. intersected === null (gh lookup failed) → conservative fallback:
+      //      label the full discovery batch, since we can't tell what shipped.
+      //      Over-labeling is recoverable (EM cleanup); under-labeling stalls.
+      //   3. intersected.length === 0 (parser succeeded, found zero matches)
+      //      → SKIP labeling + state-update entirely. The open PR exists but
+      //      doesn't reference any discovery-batch issue, which means the
+      //      skill either reported success in error (found a stale PR for a
+      //      different issue) or its PR formatting omitted the references.
+      //      Labeling here would create a self-locked issue (state filter
+      //      sees it as `implemented`, no real PR to revise) and require
+      //      manual EM cleanup on every cycle. Leave issues unlocked for the
+      //      next cycle to retry from a clean state. (slashbin-ai-foreman#16)
       const referencedAll = getReferencedIssuesFromOpenPR(
         repoConfig.githubRepo,
         repoConfig.featureBranch,
@@ -274,6 +282,16 @@ async function tryBatchImplementation(
       const intersected = referencedAll
         ? actionableIssues.filter((n) => referencedAll.includes(n))
         : null;
+
+      if (intersected !== null && intersected.length === 0) {
+        // Case 3: empty intersection — skip labeling + state-update, log
+        // warning, exit cleanly. Next cycle re-discovers and retries.
+        repoLogger.warn(
+          `Open PR found but its body/title/commits do not reference any discovered issue (#${actionableIssues.join(", #")}) — skipping label + state update so the next cycle can retry. Investigate the skill's PR formatting if this recurs.`,
+        );
+        return null;
+      }
+
       const issuesActuallyImplemented =
         intersected && intersected.length > 0 ? intersected : actionableIssues;
       if (intersected && intersected.length > 0 && intersected.length < actionableIssues.length) {
@@ -282,9 +300,9 @@ async function tryBatchImplementation(
           `Skill implemented ${intersected.length}/${actionableIssues.length} discovered issues — labeling only the implemented set`,
           { implemented: intersected, deferred: dropped },
         );
-      } else if (intersected && intersected.length === 0) {
+      } else if (intersected === null) {
         repoLogger.warn(
-          `Open PR found but its body/title/commits do not reference any discovered issue (#${actionableIssues.join(", #")}) — falling back to label all discovered issues; investigate the skill's PR formatting`,
+          `getReferencedIssuesFromOpenPR returned null (lookup failed) — labeling full discovery batch as conservative fallback (#${actionableIssues.join(", #")})`,
         );
       }
 


### PR DESCRIPTION
Closes #16

## Summary

When the implementation skill cycle finds an existing open PR but that PR doesn't reference any of the discovered actionable issues (parser succeeded, intersection is empty), the prior code labeled all discovered issues as `pr under review` anyway and added them to `.agent-state.json` `implemented` array.

This caused a self-locking loop, observed three times today on slashbin.io console issues #471/#472/#475:
1. Cycle N: implements issue A, opens PR P_A.
2. Cycle N+1: scans actionable, finds issues B+C. Skill runs but creates no new commits; the open-PR scan returns P_A.
3. P_A's body/title/commits don't mention B or C.
4. **OLD behavior**: labels B+C with `pr under review`, adds to state. Future cycles skip B+C forever (state filter), and there's no real PR to revise. EM must manually strip labels + edit state.
5. EM cleanup unlocks B+C. Next cycle re-runs steps 2-4. **Loop.**

## Fix

When `intersected.length === 0` (parser succeeded, zero matches), skip labeling + state-update entirely. Log warning, return null. Next cycle re-discovers and retries from clean state.

Three cases now explicit:
| Case | `intersected` | Action |
|---|---|---|
| 1 — matched subset | `length > 0` | Label only the matched issues (canonical skill behavior) |
| 2 — lookup failure | `null` | Conservative fallback: label full discovery batch |
| 3 — zero matches | `length === 0` | **(new)** Skip + log + return null |

The null-fallback behavior is preserved — when `gh` fails entirely, we still over-label rather than stall (since we can't tell what actually shipped). The empty-array case is now treated as "skill didn't actually ship these" rather than "shipped but didn't say so."

## Smoke test

- `npm run typecheck` ✓
- `npm run build` ✓
- No test framework in this repo; behavior change is small + reviewable from the diff.

## Verification

After merge + service restart:
1. Manually unlock console#472 + #475 again (strip `pr under review`, remove from `.agent-state.json`).
2. Wait one Foreman cycle. Skill picks up #472 OR #475 (one issue per invocation), creates real PR.
3. Next cycle finds the other issue actionable, runs skill, finds the existing PR (for the other issue), parser returns empty intersection → **NEW behavior**: logs warning, returns null. Issue stays unlocked.
4. Following cycle picks it up cleanly.

Without this fix: the EM cleanup → re-mis-label loop continues indefinitely.

## Out of scope

- Adding tests (this repo has no test framework — separate setup task).
- Changing the lookup-failure (`intersected === null`) fallback. Keeping legacy behavior there since under-labeling is worse than over-labeling when we have zero signal.
- Restructuring the three-way branch into a discriminated union or earlier return — kept the surface change minimal for reviewability.