### PR TITLE
fix: label all approved-actionable issues referenced by the PR (#18)

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -61,6 +61,68 @@ function formatGhError(err: unknown): GhFailure {
 }
 
 /**
+ * Return all `approved` open issues in the repo that have not yet
+ * progressed through the lifecycle (no `pr under review` / `pr approved` /
+ * `pr pending actions` / `ready for prod release` / `ready to close`
+ * label, not `blocked`). This is the same filter `findActionableIssues`
+ * applies BEFORE the PR-uncovered cross-check + batch cap — i.e. the
+ * full set of issues that the implementation skill might pick this cycle.
+ *
+ * Used by the orchestrator's labeling step to widen the intersection of
+ * "issues referenced by the new PR" with "issues that should accept
+ * `pr under review`": the canonical skill makes its OWN selection from
+ * the entire approved set (priority + smaller-scope-first), which can
+ * differ from the Foreman's discovery batch (PR-uncovered subset, capped
+ * at MAX_BATCH_SIZE). Without this widening, when the skill picks an
+ * approved issue that wasn't in the discovery batch, the resulting PR
+ * gets a real merge but no `pr under review` label, leaving the EM with
+ * no signal. (slashbin-ai-foreman#18)
+ *
+ * Returns [] on any gh failure (treat as "nothing to widen to" rather
+ * than throwing — the caller already has the discovery batch as a
+ * fallback, and a labeling miss is recoverable).
+ */
+export function findAllApprovedActionableIssues(
+  config: RepoConfig,
+  logger: Logger,
+): number[] {
+  const repo = config.githubRepo;
+  try {
+    const json = gh([
+      "issue", "list",
+      "--repo", repo,
+      "--state", "open",
+      "--label", config.triggerLabel,
+      "--json", "number,labels",
+      "--limit", "100",
+    ], config.repoPath);
+    const issues: GhIssue[] = JSON.parse(json || "[]");
+
+    const lifecycleLabels = [
+      "pr under review",
+      "pr approved",
+      "pr pending actions",
+      "ready for prod release",
+      "ready to close",
+    ];
+
+    const actionable: number[] = [];
+    for (const issue of issues) {
+      const labels = issue.labels.map((l) => l.name);
+      if (labels.includes("blocked")) continue;
+      if (lifecycleLabels.some((l) => labels.includes(l))) continue;
+      actionable.push(issue.number);
+    }
+    return actionable;
+  } catch (err) {
+    logger.warn("findAllApprovedActionableIssues failed; returning [] (labeling will fall back to discovery batch)", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/**
  * Gate check: find approved issues that haven't progressed through
  * the lifecycle AND don't already have a PR. Returns the uncovered
  * issue numbers (capped to MAX_BATCH_SIZE), or empty array if none.

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,6 +2,7 @@ import type { AgentConfig, RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import {
   findActionableIssues,
+  findAllApprovedActionableIssues,
   hasPendingRevisions,
   findPendingRevisions,
   transitionRevisionLabels,
@@ -248,30 +249,31 @@ async function tryBatchImplementation(
       lastFailureReason.delete(repoName);
       failureHitMaxAt.delete(repoName);
 
-      // Filter the discovered batch to only issues the implementation skill
-      // actually addressed in the resulting PR. The canonical
-      // implement-approved-issues skill picks ONE issue per invocation —
-      // labeling all N discovered issues as "pr under review" wedges the
-      // unpicked ones forever (they look like they have a PR open but the
-      // PR doesn't reference them, so revision never fires). Parse the open
-      // PR's body + title + commits for keyword references and intersect
-      // with the discovery list.
+      // Filter to only issues the implementation skill actually addressed in
+      // the resulting PR. The canonical implement-approved-issues skill picks
+      // ONE issue per invocation, AND it picks from the entire approved set
+      // (priority + smaller-scope-first), not necessarily from the Foreman's
+      // discovery batch. So the labeling-eligible set is the broader
+      // "all-approved-and-actionable" set — not just `actionableIssues`
+      // (which is also PR-uncovered + capped at MAX_BATCH_SIZE).
       //
-      // Three cases:
-      //   1. intersected.length > 0 → label only the matched subset (the
-      //      typical canonical-skill case).
-      //   2. intersected === null (gh lookup failed) → conservative fallback:
-      //      label the full discovery batch, since we can't tell what shipped.
-      //      Over-labeling is recoverable (EM cleanup); under-labeling stalls.
-      //   3. intersected.length === 0 (parser succeeded, found zero matches)
-      //      → SKIP labeling + state-update entirely. The open PR exists but
-      //      doesn't reference any discovery-batch issue, which means the
-      //      skill either reported success in error (found a stale PR for a
-      //      different issue) or its PR formatting omitted the references.
-      //      Labeling here would create a self-locked issue (state filter
-      //      sees it as `implemented`, no real PR to revise) and require
-      //      manual EM cleanup on every cycle. Leave issues unlocked for the
-      //      next cycle to retry from a clean state. (slashbin-ai-foreman#16)
+      // Three cases for the intersection of `referencedAll ∩ allActionable`:
+      //   1. matched.length > 0 → label the matched subset.
+      //   2. referencedAll === null (gh lookup failed) → conservative
+      //      fallback: label the discovery batch (`actionableIssues`), since
+      //      we can't tell what shipped. Over-labeling is recoverable (EM
+      //      cleanup); under-labeling stalls.
+      //   3. matched.length === 0 (parser succeeded, found zero matches in
+      //      the broader actionable set) → SKIP labeling + state-update
+      //      entirely. The open PR exists but doesn't reference any
+      //      currently-actionable approved issue. Labeling discovery-batch
+      //      issues here would create self-locked issues (state filter sees
+      //      them as `implemented`, no real PR to revise), requiring manual
+      //      EM cleanup every cycle. (slashbin-ai-foreman#16)
+      //
+      // Widening to allActionable (vs just actionableIssues) is the
+      // slashbin-ai-foreman#18 fix: if the skill picked an out-of-batch
+      // approved issue, the resulting PR still gets correctly labeled.
       const referencedAll = getReferencedIssuesFromOpenPR(
         repoConfig.githubRepo,
         repoConfig.featureBranch,
@@ -279,28 +281,39 @@ async function tryBatchImplementation(
         repoConfig.repoPath,
         repoLogger,
       );
-      const intersected = referencedAll
-        ? actionableIssues.filter((n) => referencedAll.includes(n))
+      const allActionable = findAllApprovedActionableIssues(repoConfig, repoLogger);
+      const labelingCandidates = Array.from(new Set([...actionableIssues, ...allActionable]));
+      const matched = referencedAll
+        ? labelingCandidates.filter((n) => referencedAll.includes(n))
         : null;
 
-      if (intersected !== null && intersected.length === 0) {
+      if (matched !== null && matched.length === 0) {
         // Case 3: empty intersection — skip labeling + state-update, log
         // warning, exit cleanly. Next cycle re-discovers and retries.
         repoLogger.warn(
-          `Open PR found but its body/title/commits do not reference any discovered issue (#${actionableIssues.join(", #")}) — skipping label + state update so the next cycle can retry. Investigate the skill's PR formatting if this recurs.`,
+          `Open PR found but its body/title/commits do not reference any actionable approved issue (discovery batch: #${actionableIssues.join(", #")}; broader set: #${labelingCandidates.join(", #")}) — skipping label + state update so the next cycle can retry. Investigate the skill's PR formatting if this recurs.`,
         );
         return null;
       }
 
       const issuesActuallyImplemented =
-        intersected && intersected.length > 0 ? intersected : actionableIssues;
-      if (intersected && intersected.length > 0 && intersected.length < actionableIssues.length) {
-        const dropped = actionableIssues.filter((n) => !intersected.includes(n));
-        repoLogger.info(
-          `Skill implemented ${intersected.length}/${actionableIssues.length} discovered issues — labeling only the implemented set`,
-          { implemented: intersected, deferred: dropped },
-        );
-      } else if (intersected === null) {
+        matched && matched.length > 0 ? matched : actionableIssues;
+      if (matched && matched.length > 0) {
+        const fromBatch = matched.filter((n) => actionableIssues.includes(n));
+        const fromBroader = matched.filter((n) => !actionableIssues.includes(n));
+        const dropped = actionableIssues.filter((n) => !matched.includes(n));
+        if (fromBroader.length > 0) {
+          repoLogger.info(
+            `Skill implemented ${matched.length} issue(s) — ${fromBatch.length} from discovery batch, ${fromBroader.length} from broader actionable set (skill priority differs from Foreman batch order)`,
+            { implemented: matched, fromBatch, fromBroader, deferred: dropped },
+          );
+        } else if (matched.length < actionableIssues.length) {
+          repoLogger.info(
+            `Skill implemented ${matched.length}/${actionableIssues.length} discovered issues — labeling only the implemented set`,
+            { implemented: matched, deferred: dropped },
+          );
+        }
+      } else if (referencedAll === null) {
         repoLogger.warn(
           `getReferencedIssuesFromOpenPR returned null (lookup failed) — labeling full discovery batch as conservative fallback (#${actionableIssues.join(", #")})`,
         );


### PR DESCRIPTION
Closes #18

## Summary

Widen the labeling intersection from the Foreman's discovery batch (`actionableIssues`) to the full set of approved-actionable issues in the repo. The canonical implement-approved-issues skill picks from the entire approved set using its own priority rules — which can pick an issue NOT in the Foreman's batch (PR-uncovered + capped at MAX_BATCH_SIZE).

Without this fix, when the skill picks an out-of-batch issue, the resulting PR is real but neither the discovery-batch issues nor the actually-implemented issue get \`pr under review\`.

## Observed defect

2026-05-03 01:30 UTC, console repo, cycle 2 (post-#16-fix verification):

| What | Result |
|---|---|
| Discovery batch | `[#472]` |
| Skill pick | `#475` (also approved+chore, smaller scope per canonical skill priority) |
| PR created | `#486` (real, references `#475`) |
| `referencedAll ∩ actionableIssues` (old logic) | `[475] ∩ [472]` = `[]` |
| #16 fix outcome | Correctly skipped #472 ✓ |
| #18 defect | #475 also unlabeled ✗ |

## Fix

1. New helper `findAllApprovedActionableIssues` in `github.ts` — returns the post-lifecycle-filter actionable set (same filter as `findActionableIssues` line 97 \`actionable\`, but exposed pre-PR-cross-check + uncapped).
2. Orchestrator's labeling intersection now uses \`labelingCandidates = actionableIssues ∪ allActionable\` instead of just \`actionableIssues\`.
3. Conservative fallback on gh failure: returns \`[]\` so the labeling step falls back to discovery batch via existing logic.

The empty-intersection skip from #16 is preserved (now over the broader set, so even more accurate at detecting "skill didn't ship anything actionable").

Logging differentiates the three cases:
- All matched issues from discovery batch (typical canonical case)
- Some matched from broader set (skill picked out-of-batch, this PR's target)
- gh lookup failure (conservative fallback, unchanged)

## Smoke test

- \`npm run typecheck\` ✓
- \`npm run build\` ✓
- No test framework in this repo; behavior change is small + reviewable from the diff.

## Verification post-deploy

After merge + restart:
1. Console#472 was already unlocked from the foreman#16 verification cycle. Now also unlock console#475 (manually labeled \`pr under review\` after the prior cycle since the auto-labeling missed it).
2. Wait for next Foreman cycle to pick up either issue.
3. Confirm: skill creates PR, the actually-implemented issue gets \`pr under review\` automatically (no manual EM step).

## Out of scope

- Changing how the canonical skill selects issues (its priority rules are correct — the gap was always Foreman-side).
- Refactoring \`findActionableIssues\` to return both batch + broader set in one call. The duplicate gh query is cheap (~50ms) and keeps surface change minimal.