### PR TITLE
feat: instruct agent to fetch and Read image references in issue bodies (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ The Foreman delegates work by invoking Claude Code skills on each service repo. 
 
 The Foreman passes the issue context to Claude and instructs it to read and follow the skill. The skill defines the repo-specific implementation workflow — how to branch, test, and structure the PR.
 
+## Image handling in issue bodies
+
+Claude is multimodal — when an issue body or PR review comment contains markdown image references like `![alt](https://...)`, those images are part of the spec (mockups, screenshots, walkthrough frames). The Foreman appends instructions to its default and skill-driven prompts telling the agent to fetch each image to a temp file and `Read` it, so the model can see image content.
+
+For private-repo image URLs (e.g. `github.com/<owner>/<repo>/raw/<branch>/<path>`) the fetch uses `GH_TOKEN`-authed `curl`. For public CDN URLs (e.g. `github.com/user-attachments/...`) no auth is required.
+
+This is automatic for the built-in prompts (`skillPath` and the default implement/revise prompts). If you supply a fully custom `prompt` in config, include your own image-handling guidance — the Foreman does not modify custom prompts.
+
 ## Programmatic usage
 
 ```typescript

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -66,6 +66,21 @@ interface SpawnResult {
   timedOut: boolean;
 }
 
+// Claude is multimodal — when issue bodies or PR review comments include
+// markdown image references like ![alt](url), the agent must fetch each image
+// to a local file and Read it. Without this, the model sees only the URL string
+// and is blind to visual specs (mockups, screenshots, walkthrough frames).
+//
+// Authorization header is required for private-repo URLs
+// (e.g. github.com/<owner>/<repo>/raw/<branch>/<path>) and harmless for public
+// CDN URLs (e.g. github.com/user-attachments/...).
+const IMAGE_HANDLING_INSTRUCTIONS = `IMAGE HANDLING: If an issue body or PR review comment contains markdown image references like \`![alt](https://...)\`, those images are part of the spec. Fetch each image to a temp file and Read it so you can see it:
+
+  curl -sL -H "Authorization: token $GH_TOKEN" -o /tmp/foreman-image-<n>.png "<url>"
+  Then call the Read tool on /tmp/foreman-image-<n>.png — the multimodal model will see the image content.
+
+The Authorization header is required for private-repo URLs (github.com/.../raw/...) and harmless for public CDN URLs (github.com/user-attachments/...). If a fetch fails, log a warning and proceed with the text spec — do not abort the implementation.`;
+
 function spawnClaude(
   prompt: string,
   config: RepoConfig,
@@ -162,8 +177,10 @@ export async function implementApprovedIssues(
   let prompt: string;
 
   if (config.skillPath) {
-    prompt = `Read and follow the skill at ${config.skillPath}.\n\nImplement all approved issues for this repository. The skill defines the full workflow — follow it exactly.`;
+    prompt = `Read and follow the skill at ${config.skillPath}.\n\nImplement all approved issues for this repository. The skill defines the full workflow — follow it exactly.\n\n${IMAGE_HANDLING_INSTRUCTIONS}`;
   } else if (config.prompt) {
+    // Custom user prompt — don't auto-modify (backward compat). Users who want
+    // image handling in a custom prompt should include their own instructions.
     prompt = config.prompt;
   } else {
     const issueScope = issueNumbers && issueNumbers.length > 0
@@ -176,6 +193,8 @@ export async function implementApprovedIssues(
 4. Push to ${config.featureBranch} and create a PR targeting ${config.baseBranch}.
 
 IMPORTANT: In PR descriptions, use "Related to #N" — NEVER use "Closes #N" or "Fixes #N". Issues are closed by the EM after production verification, not on dev merge.
+
+${IMAGE_HANDLING_INSTRUCTIONS}
 
 Work autonomously. Do not ask questions.`;
   }
@@ -329,7 +348,7 @@ export async function revisePRFeedback(
   let prompt: string;
 
   if (config.revisionSkillPath) {
-    prompt = `Read and follow the skill at ${config.revisionSkillPath}.\n\nRevise PR #${prNumber || "(pending)"} which has review feedback for this repository. The skill defines the full workflow — follow it exactly.${prContext}${labelNote}`;
+    prompt = `Read and follow the skill at ${config.revisionSkillPath}.\n\nRevise PR #${prNumber || "(pending)"} which has review feedback for this repository. The skill defines the full workflow — follow it exactly.${prContext}${labelNote}\n\n${IMAGE_HANDLING_INSTRUCTIONS}`;
   } else {
     prompt = `Revise PR #${prNumber || "(find open PRs with review feedback)"} in this repository.
 
@@ -340,6 +359,8 @@ export async function revisePRFeedback(
 5. Commit fixes with message: fix: address review feedback (#${prNumber || "<number>"})
 6. Push to the PR branch.
 ${prContext}${labelNote}
+
+${IMAGE_HANDLING_INSTRUCTIONS}
 
 Work autonomously. Do not ask questions.`;
   }


### PR DESCRIPTION
## Summary

Closes #20.

Append image-handling instructions to all four agent prompt branches so the multimodal Claude model sees images referenced in issue bodies / PR review comments instead of just the URL string.

The CLI (`claude --print "<prompt>"`) takes text-only prompts and doesn't accept inline image bytes, so a Foreman-side fetch-and-attach approach isn't workable. Prompt engineering is the minimal change: instruct the agent to `curl` image URLs to a temp file and call `Read` on each — the Read tool renders the image content to the multimodal LLM.

## What changed

- `src/agent.ts`:
  - New `IMAGE_HANDLING_INSTRUCTIONS` constant with the fetch + Read pattern and auth-header guidance (required for private-repo URLs, harmless for public CDN URLs)
  - Appended to: `implementApprovedIssues` (skill + default branches) and `revisePRFeedback` (skill + default branches)
  - **Custom user prompts (`config.prompt`) are unchanged** — backward compat
- `README.md`: new section under "Using with skills" documenting the behavior

## Backward compatibility

Additive only. No `.ai-agent.json` schema changes, no env-var contract changes, no behavioral changes for issues without images. Pre-existing configs load and run identically. Custom prompt users supply their own image-handling guidance if they need it.

## Out of scope

- Foreman-side message-content embedding (would require switching from CLI spawn to Agent SDK programmatic use — large architectural change)
- MIME type / size / count caps (handled implicitly by Claude's Read tool and context window)
- Opt-in flag (`AI_AGENT_VISION` env var) — behavior is automatic and benign for image-free issues

## Test plan

- [ ] Typecheck passes (`npm run typecheck`) ✅
- [ ] Manual: file a test issue with an image in a private repo, run Foreman once, verify the model fetches and Reads the image
- [ ] Manual: file a test issue with a public CDN image, verify the fetch works without auth
- [ ] Backward compat: pre-existing approved issue without images implements identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
