### PR TITLE
fix(orchestrator): self-heal stale 'implemented' cache entries with no delivering PR

### DIFF
--- a/docs/implemented-cache-self-heal.md
+++ b/docs/implemented-cache-self-heal.md
@@ -1,0 +1,67 @@
+# `implemented` cache self-heal — current-vs-correct model (Repeated-S1)
+
+**Status:** decision artifact for the fix in `src/orchestrator.ts` (the
+`tryBatchImplementation` `implemented`-filter region). Owner-approved
+2026-05-19 (Option A: fix the model, not another attribution patch).
+
+## The recurring defect (the family)
+
+`slashbin-ai-foreman#16`, `#18`, and the 2026-05-19 `Slashbin-console#540`
+incident are the same bug: an issue ends up in persistent
+`RepoState.implemented` (a permanent skip list) **without a PR that actually
+delivers it**, and nothing ever removes it → the issue is skipped every
+implement cycle, forever ("self-locked", "manual EM cleanup every cycle").
+
+## Why it keeps happening (current model)
+
+- All issues for a repo share one `features` branch; one open PR on that
+  branch accumulates multiple issues' commits.
+- After a successful skill run the Foreman attributes "implemented" by
+  scanning whatever open PR sits on `features` for `#N` references
+  (`getReferencedIssuesFromOpenPR` → `matched`), then pushes those numbers
+  to `repoState.implemented`.
+- #540's commit landed on `features` *under #541's PR* (which is scoped to
+  #539). #540 was thus "referenced", marked `implemented`, and got no PR of
+  its own. Once #541 was REQUEST_CHANGES'd and #540's labels cleaned, #540
+  was `implemented`-with-no-PR → the implement filter skips it every cycle;
+  the revise phase only touches #541. Dead-zone.
+- Every prior fix (#16, #18, the Case 1/2/3 logic) patched the *attribution
+  heuristic*. The heuristic will always have edge cases on a shared branch.
+  Patch N+1 at that layer is the wrong layer (Repeated-S1: stop, fix the
+  model/invariant).
+
+## Correct model
+
+**Invariant:** `implemented[N]` ⟺ a PR that delivers N exists (open or
+merged). `findActionableIssues` already computes the authoritative negation
+of this (approved issues with **no** linked open/merged PR) — it is the same
+check the orchestrator trusts to decide what to implement.
+
+**Self-heal:** each cycle, reconcile the cache to the invariant. Any N that
+is BOTH still returned by `findActionableIssues` (no delivering PR per the
+live check) AND present in `repoState.implemented` is provably stale → prune
+it, persist, log, let it re-implement. The dead-zone becomes
+unrepresentable: an issue cannot remain `implemented` while the live
+authoritative check says it has no delivering PR.
+
+This does **not** reintroduce the re-implement loop the cache guards
+against — that loop is "a PR exists but linkage detection missed it"; here
+the same linkage check reports *no* PR, so there is nothing to loop on.
+Genuine loops stay bounded by `failureCount`/cooldown + the skip back-off.
+
+## Why this fix (not per-issue branches)
+
+Per-issue branches would also dissolve the family but change the
+`features`-branch / `.ai-agent.json` / env contract — a non-additive,
+OSS-contract-breaking change (`feedback_foreman_oss_backward_compat`). The
+self-heal is the minimal correct fix at the right layer (the invariant),
+additive, no state-shape / config / branch-model change. Per-issue branches
+remain a possible future proposal, not required to make the dead-zone
+impossible.
+
+## Scope / out of scope
+
+In: the self-heal prune + log + persist before the `alreadyImplemented`
+filter. Out: the one-time incident tail where #540's stale-scope commit is
+physically commingled on Console `features` under #541 — handled
+operationally after this lands (not a model defect).

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -186,6 +186,36 @@ async function tryBatchImplementation(
   // This prevents infinite loops where the Foreman re-implements the same
   // issues because the PR check in findActionableIssues didn't match.
   const repoState = loadRepoState(repoName);
+
+  // Self-heal the `implemented` cache (slashbin-ai-foreman #16/#18/#540 family).
+  //
+  // Invariant: `implemented[N]` must mean "a PR that delivers N exists".
+  // `findActionableIssues` already authoritatively returns only approved
+  // issues with NO linked PR (open or merged) — it is the same check the
+  // orchestrator trusts to decide what to implement. So any N that is BOTH
+  // still in `actionableIssues` (no delivering PR per the live check) AND in
+  // `repoState.implemented` is a stale, dead-zoned entry: a prior run recorded
+  // it without producing a delivering PR (PR creation failed, or its commit
+  // rode a foreign PR on the shared `features` branch). Left alone it is
+  // skipped forever with no recovery. The live no-linked-PR signal wins over
+  // the stale cache: prune so the issue is re-implemented this cycle.
+  //
+  // This cannot reintroduce the re-implement loop the cache guards against:
+  // that loop is "PR exists but the linkage check missed it" — here the same
+  // linkage check (findActionableIssues) reports NO PR, so there is nothing to
+  // loop on; true loops remain bounded by failureCount/cooldown + skip back-off.
+  // Additive only — no state shape / .ai-agent.json / branch-model change.
+  const staleImplemented = repoState.implemented.filter((n) => actionableIssues.includes(n));
+  if (staleImplemented.length > 0) {
+    repoLogger.warn(
+      `Self-heal: pruning ${staleImplemented.length} stale 'implemented' entr${staleImplemented.length === 1 ? "y" : "ies"} with no delivering PR — re-implementable: ${staleImplemented.map((n) => `#${n}`).join(", ")}`,
+    );
+    const healed = loadRepoState(repoName);
+    healed.implemented = healed.implemented.filter((n) => !staleImplemented.includes(n));
+    saveRepoState(repoName, healed);
+    repoState.implemented = healed.implemented;
+  }
+
   const alreadyImplemented = new Set(repoState.implemented);
   actionableIssues = actionableIssues.filter((n) => !alreadyImplemented.has(n));
   if (actionableIssues.length === 0) {


### PR DESCRIPTION
## Problem

Owner-approved Repeated-S1 model fix (2026-05-19, Option A — fix the model, not another attribution patch). The Foreman dead-zone family (foreman#16, foreman#18, the 2026-05-19 `Slashbin-console#540` incident): an issue lands in persistent `RepoState.implemented` (permanent skip list) **without a PR that actually delivers it**, and nothing removes it → skipped every implement cycle, forever.

## Fix

Enforce the invariant `implemented[N] ⇔ a delivering PR exists (open or merged)` by reconciling the cache to it each cycle, immediately before the `alreadyImplemented` filter in `tryBatchImplementation`. Any N that is BOTH still returned by `findActionableIssues` (the authoritative no-linked-PR check the orchestrator already trusts) AND present in `repoState.implemented` is provably stale → prune it, persist, log (`WARN Self-heal: pruning …`), let it re-implement. The dead-zone becomes unrepresentable.

Additive, no state-shape / config / branch-model change (`feedback_foreman_oss_backward_compat`). Does NOT reintroduce the re-implement loop the cache guards against (that loop is 'a PR exists but linkage missed it'; here the same linkage check reports *no* PR).

Full model analysis: `docs/implemented-cache-self-heal.md`.

## Companion / scope

This is the **cache half**. The **branch half** (a polluted shared `features` branch whose reconciliation PR keeps masking the pruned issue) is tracked separately in foreman#24 — not closed by this PR. Verified in the wild 2026-05-19: `Slashbin-console#542` regenerates every cycle and re-links `#540`, so this self-heal cannot fire for `#540` until the branch tail is cleared (owner-only: protected `features` force-push).

## References
- foreman#16, foreman#18 (dead-zone family); `Slashbin-console#540`/#541/#542 incident
- foreman#24 (companion branch-half)
- `docs/implemented-cache-self-heal.md`