### PR TITLE
fix: reason-aware skip-cache recheck — clear transient skips when precondition resolves

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -20,7 +20,7 @@ import {
   type PendingRevisionInfo,
 } from "./github.js";
 import { implementApprovedIssues, revisePRFeedback, type ImplementationResult, type RevisionResult } from "./agent.js";
-import { reconcileRepo } from "./reconciler.js";
+import { reconcileRepo, checkLocalBranchDivergence } from "./reconciler.js";
 import { verifyPRExists } from "./github.js";
 import { loadRepoState, saveRepoState } from "./state.js";
 
@@ -150,6 +150,42 @@ export async function runCycle(
   return { didWork: totalProcessed > 0, lastImplementation: lastResult, events };
 }
 
+/**
+ * Classify a recorded skip reason as transient + currently-resolved. Returns
+ * true only when (a) the reason matches a known transient pattern AND (b) the
+ * underlying precondition can be re-checked from this host AND (c) the check
+ * confirms the precondition no longer holds. Returning false is safe — the
+ * back-off continues normally.
+ *
+ * Known transient patterns:
+ * - "diverged from origin/<branch>" — local working clone ahead/behind origin;
+ *   resolved when both are 0. The skill emits this when `git pull origin
+ *   features` fails on a divergent branch state, typically caused by an EM
+ *   session leaving polluted refs in the shared clone (see
+ *   feedback_em_clone_stay_on_main). An EM manual reconcile
+ *   (`git branch -f features origin/features`) clears the cause but cannot
+ *   reach into the daemon's skip cache; this recheck lets the orchestrator
+ *   notice the cause is gone and admit on the next cycle instead of waiting
+ *   out the full 30-min back-off.
+ *
+ * Add new transient patterns here as they are identified. Durable reasons
+ * (issue-body says "investigation only", "no immediate code change") MUST
+ * stay caught by the default `return false` — those don't go away on retry.
+ */
+function isResolvedTransientSkip(
+  reason: string,
+  repoPath: string,
+  logger: Logger,
+): boolean {
+  const divergenceMatch = reason.match(/diverged from origin\/(\S+?)\b/i);
+  if (divergenceMatch) {
+    const branch = divergenceMatch[1];
+    const div = checkLocalBranchDivergence(repoPath, branch, logger);
+    return div !== null && div.ahead === 0 && div.behind === 0;
+  }
+  return false;
+}
+
 async function tryBatchImplementation(
   repoConfig: RepoConfig,
   logger: Logger,
@@ -229,20 +265,46 @@ async function tryBatchImplementation(
   // we don't burn an agent run every cycle correctly doing nothing.
   // Skipped entries are cleared automatically when the issue is re-implemented
   // (success path) or when the back-off expires.
+  //
+  // Reason-aware recheck: some skip reasons describe a TRANSIENT precondition
+  // (e.g., "local features branch diverged from origin/features") that an EM
+  // session can manually resolve mid-back-off. Before honoring the back-off,
+  // re-run the precondition check; if it now passes, admit the issue and clear
+  // the stale skip entry. This prevents the cache from pinning a dead-zone
+  // 30 minutes past an already-applied manual reconcile.
   const skippedMap = repoState.skipped ?? {};
   const SKIP_BACKOFF_MS = 30 * 60 * 1000; // 30 min
   const now = Date.now();
-  const stillBackedOff: number[] = [];
+  const stillBackedOff: { n: number; reason: string }[] = [];
+  const resolvedTransient: { n: number; reason: string }[] = [];
   actionableIssues = actionableIssues.filter((n) => {
     const entry = skippedMap[n];
     if (!entry) return true;
     const age = now - new Date(entry.lastSkippedAt).getTime();
     if (Number.isNaN(age) || age >= SKIP_BACKOFF_MS) return true;
-    stillBackedOff.push(n);
+    if (isResolvedTransientSkip(entry.reason, repoConfig.repoPath, repoLogger)) {
+      resolvedTransient.push({ n, reason: entry.reason });
+      return true;
+    }
+    stillBackedOff.push({ n, reason: entry.reason });
     return false;
   });
+  if (resolvedTransient.length > 0) {
+    repoLogger.info(
+      `Cleared ${resolvedTransient.length} resolved-transient skip entr${resolvedTransient.length === 1 ? "y" : "ies"}: ${resolvedTransient.map(({ n }) => `#${n}`).join(", ")}`,
+    );
+    const healed = loadRepoState(repoName);
+    healed.skipped = healed.skipped ?? {};
+    for (const { n } of resolvedTransient) delete healed.skipped[n];
+    saveRepoState(repoName, healed);
+    repoState.skipped = healed.skipped;
+  }
   if (stillBackedOff.length > 0) {
-    repoLogger.debug(`Backing off ${stillBackedOff.length} previously-skipped issue(s): ${stillBackedOff.map(n => `#${n}`).join(", ")}`);
+    // Promoted DEBUG → INFO so silent skip-cache filtering is visible in the
+    // journal (otherwise the pipeline appears stalled while the cache holds it).
+    repoLogger.info(
+      `Backing off ${stillBackedOff.length} previously-skipped issue(s): ${stillBackedOff.map(({ n, reason }) => `#${n} (${reason.split("\n")[0].slice(0, 100)})`).join("; ")}`,
+    );
   }
   if (actionableIssues.length === 0) {
     if (failures > 0) failureCount.set(repoName, 0);

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -25,6 +25,50 @@ function git(args: string[], cwd: string): string {
   }).trim();
 }
 
+export interface LocalBranchDivergence {
+  ahead: number;
+  behind: number;
+}
+
+/**
+ * Inspect divergence of a local branch ref vs `origin/<branch>` in a shared
+ * Foreman working clone. Fetches the branch first to ensure origin refs are
+ * current. Returns `null` if any git call fails (clone gone, network blip,
+ * branch missing) — callers must treat null as "unknown, don't act."
+ *
+ * Used by the orchestrator's skip-cache filter to re-check whether a
+ * previously-recorded "branch diverged" skip reason is still true. When EM
+ * manually reconciles a polluted local features ref (force-align to origin),
+ * the skip cache's 30-min back-off would otherwise pin the issue dead-zoned
+ * for that whole window before auto-clearing.
+ */
+export function checkLocalBranchDivergence(
+  repoPath: string,
+  branch: string,
+  logger: Logger,
+): LocalBranchDivergence | null {
+  try {
+    git(["fetch", "origin", branch, "--quiet"], repoPath);
+    const ahead = parseInt(
+      git(["rev-list", "--count", `origin/${branch}..${branch}`], repoPath),
+      10,
+    );
+    const behind = parseInt(
+      git(["rev-list", "--count", `${branch}..origin/${branch}`], repoPath),
+      10,
+    );
+    if (Number.isNaN(ahead) || Number.isNaN(behind)) return null;
+    return { ahead, behind };
+  } catch (err) {
+    logger.warn("Local branch divergence check failed", {
+      repoPath,
+      branch,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
 /**
  * List remote branches matching the feature branch prefix.
  * Feature branches are named `features-*`, not a single `features` ref.


### PR DESCRIPTION
## Problem

The orchestrator's skip-cache filter applies a 30-min back-off to any issue the agent declined via `FOREMAN_RESULT: skipped reason="..."`. That's right for durable causes (investigation-only, blocked-on-external-verification) — re-running the agent every cycle would burn budget without progress.

But some skip reasons describe **transient preconditions** that an external action (EM session, ops) can fix mid-back-off. The cache doesn't know the cause is gone, so it keeps the issue dead-zoned for the full window past the actual fix.

The most concrete case: `local features branch diverged from origin/features (N ahead, M behind)`. This arises when the shared Foreman working clone gets polluted refs (a Claude session running in the same clone misreads its branch and pulls/rebases incorrectly). The implement skill's `git pull origin features` fails, the agent emits the skip trailer with that reason, and the orchestrator caches it. EM force-aligns local features to origin (`git branch -f features origin/features`) to fix the cause — but the cache stays armed for ~30 min.

## Repro

Caught: `xrgarcia/jerky-mcp-services#51` sat dead-zoned ~21 min past EM's manual reconcile (skip cached at 15:00:28, reconcile at ~15:21, would auto-clear at 15:30:28). EM had to manually edit `.agent-state.json` to unblock. Inside a running daemon. Not the workflow we want.

## Change

**`reconciler.ts`** — exports `checkLocalBranchDivergence(repoPath, branch, logger): { ahead, behind } | null`. Small wrapper around `git fetch` + `git rev-list --count`. Returns null on any failure → "unknown, don't act."

**`orchestrator.ts`** — adds `isResolvedTransientSkip(reason, repoPath, logger)`. Classifier: matches `diverged from origin/<branch>` against the recorded reason, runs the divergence check, returns true only when both ahead and behind are 0. Durable reasons fall through to the default deny.

**Skip-cache filter loop** — before honoring the back-off, calls the classifier. On true → admit + queue for cache prune. After the loop, prunes resolved entries via `loadRepoState` → mutate → `saveRepoState` (atomic file rewrite, same path the manual workaround used).

**Logging** — promotes the previously-DEBUG "Backing off N issue(s)" log to INFO with each entry's reason inlined. Silent skip-cache filtering had made the pipeline appear stalled in journalctl — now visible.

## Compatibility

Additive only:
- No `.ai-agent.json` shape change
- No env-var contract change
- No behaviour change for durable skip reasons (the default still denies)
- New `LocalBranchDivergence` interface exported from reconciler.ts
- Existing state file schema unchanged (uses the same `skipped` map shape)

## Verification

- `npm run build` — clean
- New code path traceable through `loadRepoState`/`saveRepoState` (same primitives the existing implemented-cache self-heal uses, per slashbin-ai-foreman#25)
- Restart-tested live on the same daemon that exhibited the dead-zone
- Manual #51 unblock (atomic JSON write) used as the test for the cache-prune step; the new code automates that

## Test plan

- [ ] After merge, cause a divergence on a test repo, observe the skip
- [ ] Force-align local branch to origin
- [ ] Confirm the next cycle logs `Cleared 1 resolved-transient skip entry: #N` at INFO and admits the issue
- [ ] Confirm a durable skip (e.g., investigation-only issue) still respects the 30-min back-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)